### PR TITLE
Fix Safari raising a network error when downloading a file

### DIFF
--- a/client/app/shared/components/download/download.component.ts
+++ b/client/app/shared/components/download/download.component.ts
@@ -74,7 +74,10 @@ export class DownloadComponent {
         this.exportService.create(this.input).subscribe(newExport => {
             if (newExport.filename) {
                 const url = '/export/' + newExport.filename;
-                window.document.location.href = url;
+                const download_window = window.open(url);
+                setTimeout(function () {
+                    download_window.close();
+                }, 999);
             } else {
                 this.alertService.info(
                     'Le download est en cours de préparation. Un email vous sera envoyé quand il sera prêt.',


### PR DESCRIPTION
Petites explications :

Lorsque l'on essaie de télécharger un fichier (zip, excel, ...) depuis Safari, on a une erreur CORS qui se produit, débouchant sur "Error: Uncaught (in promise): Error: Http failure response for /graphql: 0 Unknown".

Le problème vient de "window.document.location.href = url" que Safari semble ne pas aimer puisque la prochaine requête faite provoque justement cette erreur CORS (même si, d'après ce que j'ai vu, il n'y a pas de protection CORS mise en place sur l'app).

La solution proposée contourne le problème en lançant le téléchargement depuis un nouvel onglet. Le petit hack pas très beau du timeout permet à Safari (toujours lui...) de refermer automatiquement l'onglet, les autres navigateurs le faisant automatiquement.

Solutions testées qui ne fonctionnent pas :
 - windows.location.assign
 - windows.location.replace
 - event sur le load de la page pour la refermer quand la page est chargée (ne fonctionne pas sur Safari)
- _parent, _self, _top de window.open
