### PR TITLE
Fix quill editor not focusable when field is empty

### DIFF
--- a/client/app/card/_card.theme.scss
+++ b/client/app/card/_card.theme.scss
@@ -37,6 +37,10 @@
                 font-size: inherit !important;
                 font-family: inherit !important;
             }
+
+            quill-editor {
+                display: block;
+            }
         }
 
         .ql-editor {


### PR DESCRIPTION
Une mise à jour de `ngx-quill` a modifié le style du composant de base "quill-editor" de `display: inline` à `display: inline-block`.
[Diff](https://github.com/KillerCodeMonkey/ngx-quill/commit/8ef9eb51cad78073f8457ba945e26d85b0926df0)

Cela engendre que nos composants n'ont plus de largeur lorsqu'ils sont vides et ne peuvent plus être sélectionnés pour édition.

[magnifique demo](https://user-images.githubusercontent.com/832658/223370999-2a96d367-f18e-45e7-ac3f-e15076fb72b5.gif)

On modifie ce comportement pour revenir au fonctionnement désiré (on met block à la place de inline, cela semble plus adapté à nos besoins).