### PR TITLE
Fix mutation of frozen model

### DIFF
--- a/client/app/card/card.component.ts
+++ b/client/app/card/card.component.ts
@@ -611,8 +611,10 @@ export class CardComponent extends NaturalAbstractController implements OnInit, 
 
                 this.cardService.getOne(this.fetchedModel.id).subscribe(result => {
                     this.assertFetchedCard(this.fetchedModel);
-
-                    this.fetchedModel.collections = result!.collections;
+                    this.fetchedModel = {
+                        ...this.fetchedModel,
+                        collections: [...result!.collections],
+                    };
                     this.updateCollections();
                 });
             });

--- a/client/app/shared/components/collection-selector/collection-selector.component.ts
+++ b/client/app/shared/components/collection-selector/collection-selector.component.ts
@@ -105,7 +105,12 @@ export class CollectionSelectorComponent implements OnInit {
     public unlink(image: Cards['cards']['items'][0], collection: Cards['cards']['items'][0]['collections'][0]): void {
         this.collectionService.unlink(collection, [image]).subscribe(() => {
             const index = image.collections.findIndex(c => c.id === collection.id);
-            image.collections.splice(index, 1);
+            const splicedCollection = [...image.collections];
+            splicedCollection.splice(index, 1);
+            this.image = {
+                ...image,
+                collections: splicedCollection,
+            };
             this.alertService.info('Fiche retirée de la collection');
         });
     }
@@ -132,7 +137,10 @@ export class CollectionSelectorComponent implements OnInit {
 
         observable.subscribe(() => {
             if (this.data.images && this.data.images.length === 1 && this.data.images[0].collections) {
-                this.data.images[0].collections.push(collection as any);
+                this.data.images[0] = {
+                    ...this.data.images[0],
+                    collections: [...this.data.images[0].collections, collection as any],
+                };
             }
             this.dialogRef.close(collection);
             this.alertService.info('Fiches ajoutées');

--- a/client/app/shared/config/apollo.link.creator.ts
+++ b/client/app/shared/config/apollo.link.creator.ts
@@ -3,6 +3,7 @@ import {
     ApolloLink,
     DefaultOptions,
     InMemoryCache,
+    InMemoryCacheConfig,
     NormalizedCacheObject,
 } from '@apollo/client/core';
 import {onError} from '@apollo/client/link/error';
@@ -21,6 +22,25 @@ export const apolloDefaultOptions: DefaultOptions = {
     },
     watchQuery: {
         fetchPolicy: 'cache-and-network',
+    },
+};
+
+export const cacheConfig: InMemoryCacheConfig = {
+    typePolicies: {
+        Card: {
+            fields: {
+                collections: {
+                    // Because we always receive **all** collections at once, we
+                    // can always replace everything that exists, even if the incoming
+                    // has less collection than existing (because collections were deleted)
+                    merge: (existing, incoming) => incoming,
+                },
+            },
+        },
+        Permissions: {
+            // Incoming permissions always overwrite whatever permission might already exist
+            merge: true,
+        },
     },
 };
 
@@ -91,7 +111,7 @@ function apolloOptionsFactory(): ApolloClientOptions<NormalizedCacheObject> {
 
     return {
         link: link,
-        cache: new InMemoryCache(),
+        cache: new InMemoryCache(cacheConfig),
         defaultOptions: apolloDefaultOptions,
     };
 }


### PR DESCRIPTION
@PowerKiKi 

Lorsqu'on essaie de link / unlink une collection à une card, le message d'erreur suivant apparaît (uniquement en dev) :

ERROR TypeError: property 0 is non-configurable and can't be deleted (collection-selector.component.ts:108)
ERROR TypeError: can't define array index property past the end of an array with non-writable length (collection-selector.component.ts:135)

Je pense que c'est à cause de [cette modification](https://github.com/Ecodev/natural/commit/66ec1c549152963993fc1cfdcbd7126194f0d132).

Je suis tombé sur ces erreurs un peu par hasard, car en principe, je ne fais pas de tests "live" sur ma version de dev.

Tu peux jeter un œil au fix? J'aimerais m'assurer que c'est la bonne manière de corriger ça.