### PR TITLE
Fix error when editing a card with a new updater

### DIFF
--- a/client/app/card/card.component.ts
+++ b/client/app/card/card.component.ts
@@ -764,7 +764,15 @@ export class CardComponent extends NaturalAbstractController implements OnInit, 
             return;
         }
 
-        this.cardService.updateNow(this.model).subscribe(card => {
+        const tmpModel = {
+            ...this.model,
+            updater: {...(this.model as any).updater},
+        };
+
+        console.log(Object.isFrozen((tmpModel as any).updater)); // false
+        console.log(Object.isFrozen((this.model as any).updater)); // true
+
+        this.cardService.updateNow(tmpModel).subscribe(card => {
             this.alertService.info('Mis à jour');
             this.institution = card.institution;
             this.artists = card.artists;


### PR DESCRIPTION
When we update a card with a new updater, the following error occurs:

card.component.ts:731  ERROR TypeError: Cannot assign to read only property 'id' of object '[object Object]'
    at baseAssignValue (_baseAssignValue.js:21:16)
    at assignMergeValue (_assignMergeValue.js:16:20)
    at _baseMerge.js:37:23
    at _createBaseFor.js:17:11
    at baseMerge (_baseMerge.js:24:10)
    at baseMergeDeep (_baseMergeDeep.js:88:5)
    at _baseMerge.js:27:20
    at _createBaseFor.js:17:11
    at baseMerge (_baseMerge.js:24:10)
    at mergeWith.js:36:12

This error occurs because this.model.updater is frozen when we do a updateNow(this.model).

It occurs only in development (in production no error are logged and don't block the update).