### PR TITLE
Prevent excessive file size increase when autorotating TIFF images

### DIFF
--- a/tests/data/query/junior-can-update-image.php
+++ b/tests/data/query/junior-can-update-image.php
@@ -62,7 +62,7 @@ return [
         'data' => [
             'updateCard' => [
                 'name' => 'test name',
-                'fileSize' => 97599,
+                'fileSize' => 90188,
                 'width' => 960,
                 'height' => 425,
                 'institution' => [

--- a/tests/data/query/major-can-create-card-in-other-public-collection.php
+++ b/tests/data/query/major-can-create-card-in-other-public-collection.php
@@ -13,7 +13,7 @@ return [
         'data' => [
             'createCard' => [
                 'name' => 'test name',
-                'fileSize' => 97599,
+                'fileSize' => 90188,
                 'width' => 960,
                 'height' => 425,
                 'code' => 'Test collection 2001-6014',

--- a/tests/data/query/student-can-create-card-in-his-collection.php
+++ b/tests/data/query/student-can-create-card-in-his-collection.php
@@ -13,7 +13,7 @@ return [
         'data' => [
             'createCard' => [
                 'name' => 'test name',
-                'fileSize' => 97599,
+                'fileSize' => 90188,
                 'width' => 960,
                 'height' => 425,
                 'code' => null,

--- a/tests/data/query/student-can-create-card.php
+++ b/tests/data/query/student-can-create-card.php
@@ -63,7 +63,7 @@ return [
         'data' => [
             'createCard' => [
                 'name' => 'test name',
-                'fileSize' => 97599,
+                'fileSize' => 90188,
                 'width' => 960,
                 'height' => 425,
                 'code' => null,


### PR DESCRIPTION
Problem:
When autorotating TIFF images using the Imagine library, the resulting files can sometimes double in size, even if it doesn't need to be rotated (it's the save process and not the rotate process that cause this issue). This is likely due to loss of original compression, color schema changes, or other internal re-encoding behaviors that are hard to control reliably via Imagine/Imagick.

This can lead to major issues: some rotated TIFFs exceed 150MB, which causes server errors due to memory limits being exceeded when attempting to download or process those files.

Solution:
Implemented a safeguard to avoid unnecessary autorotation and resave operations:
- Autorotation is only attempted if EXIF orientation metadata indicates it's needed.
- The rotated image is first written to a temporary file.
- If the rotated version exceeds the server's configured upload_max_filesize, the original is kept untouched and rotation is skipped.

Limitation:
This means that some images may not be rotated if doing so would produce an oversized file. While not perfect, this approach balances rotation correctness with system stability and avoids large unexpected file growth.