### PR TITLE
Upgrade composer in github actions to fix vulnerability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         strategy:
             matrix:
                 php-versions: ['8.5']
-                composer-version: ['2.8']
+                composer-version: ['2.9']
                 mariadb-version: ['11.4']
                 node-version: ['22']
         env:


### PR DESCRIPTION
Github est en train de publier une feature qui provoque le leak des clés de github actions via composer. Il faut upgrader composer 2.9.8 (au moins) dans les meilleurs délais.

https://blog.packagist.com/composer-2-9-8-and-2-2-28-fix-github-actions-token-disclosure-in-error-messages/

J'ai upgradé la version sans avoir fait de tests supplémentaires, donc à voir si d'autres changements sont nécessaires.

Les logs d'activité semblent clean, on est donc plutôt dans la prévention.