### PR TITLE
Enable strict DB #12569

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,6 @@ jobs:
 
             - name: Prepare app
               run: |
-                  mariadb --protocol=tcp --user=root --execute='SET GLOBAL sql_mode = "";'
                   cp example.env .env
                   cp config/autoload/local.php.dist config/autoload/local.php
 

--- a/config/autoload/doctrine.global.php
+++ b/config/autoload/doctrine.global.php
@@ -14,7 +14,7 @@ return [
                     'password' => '',
                     'port' => 3306,
                     'driverOptions' => [
-                        Pdo\Mysql::ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
+                        Pdo\Mysql::ATTR_INIT_COMMAND => 'SET NAMES utf8mb4; SET sql_mode = STRICT_TRANS_TABLES;',
                     ],
                     'defaultTableOptions' => [
                         'charset' => 'utf8mb4',

--- a/dev/config/my.cnf
+++ b/dev/config/my.cnf
@@ -25,6 +25,3 @@ sort_buffer_size=1M
 
 table_open_cache=4500
 table_definition_cache=4000
-
-# Make non-strict mode like on previous server
-sql_mode = ""


### PR DESCRIPTION
Tous nos projets migrent sur un MariaDB en mode strict. Dilps est _compatible_ avec la mode strict depuis https://github.com/unil-lettres/dilps-tiresias/commit/35321df15e58a64fdd6cb041849b83f5b1afafa7 (obligatoire).

Cette PR _active_ le mode strict dans votre docker, et donc à terme sur votre production. Cette deuxième partie est optionnelle, notamment si vous faites des accès à la BD par un autre moyen que la webapp.